### PR TITLE
Add 6 months scores to ETL process

### DIFF
--- a/packages/nextjs/components/onchain-impact-dashboard/LeaderboardTable/SkeletonTable.tsx
+++ b/packages/nextjs/components/onchain-impact-dashboard/LeaderboardTable/SkeletonTable.tsx
@@ -23,6 +23,9 @@ const SkeletonTable = () =>
       <td>
         <div className="h-2 w-7 bg-slate-300 rounded"></div>
       </td>
+      <td>
+        <div className="h-2 w-7 bg-slate-300 rounded"></div>
+      </td>
     </tr>
   ));
 

--- a/packages/nextjs/components/onchain-impact-dashboard/LeaderboardTable/index.tsx
+++ b/packages/nextjs/components/onchain-impact-dashboard/LeaderboardTable/index.tsx
@@ -31,6 +31,7 @@ const HEADERS = [
   ["7", "7 days"],
   ["30", "30 days"],
   ["90", "90 days"],
+  ["180", "180 days"],
 ];
 
 const LeaderboardTable = ({ projects, loading, selectedMetricName = "impact_index" }: Props) => {
@@ -42,8 +43,8 @@ const LeaderboardTable = ({ projects, loading, selectedMetricName = "impact_inde
   );
   const sortedProjects = projectsMatchingSearch.sort((a, b) => {
     if (sortValue) {
-      if (["7", "30", "90"].includes(sortValue)) {
-        const range = sortValue as "7" | "30" | "90";
+      if (["7", "30", "90", "180"].includes(sortValue)) {
+        const range = sortValue as "7" | "30" | "90" | "180";
         const aMovement = a.movementByMetric[selectedMetricName][range];
         const bMovement = b.movementByMetric[selectedMetricName][range];
         if (sortDesc) {
@@ -102,7 +103,7 @@ const LeaderboardTable = ({ projects, loading, selectedMetricName = "impact_inde
                 <SkeletonTable />
               ) : !sortedProjects.length ? (
                 <tr>
-                  <td colSpan={5} className="text-center">
+                  <td colSpan={6} className="text-center">
                     No projects found
                   </td>
                 </tr>
@@ -127,6 +128,7 @@ const LeaderboardTable = ({ projects, loading, selectedMetricName = "impact_inde
                     <td>{formatMovement(item.movementByMetric[selectedMetricName]["7"])}</td>
                     <td>{formatMovement(item.movementByMetric[selectedMetricName]["30"])}</td>
                     <td>{formatMovement(item.movementByMetric[selectedMetricName]["90"])}</td>
+                    <td>{formatMovement(item.movementByMetric[selectedMetricName]["180"])}</td>
                   </tr>
                 ))
               )}

--- a/packages/nextjs/pages/api/etl/index.ts
+++ b/packages/nextjs/pages/api/etl/index.ts
@@ -122,16 +122,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const day7 = dates[7];
       const day30 = dates[30];
       const day90 = dates[90];
+      const day180 = dates[180];
 
       const projectMovementOps: any[] = [];
 
       // Fetch all projects and required scores at once
-      const [projects, scoresToday, scoresDay7, scoresDay30, scoresDay90] = await Promise.all([
+      const [projects, scoresToday, scoresDay7, scoresDay30, scoresDay90, scoresDay180] = await Promise.all([
         Project.find({}).lean(),
         TempProjectScore.find({ date: today }).lean(),
         TempProjectScore.find({ date: day7 }).lean(),
         TempProjectScore.find({ date: day30 }).lean(),
         TempProjectScore.find({ date: day90 }).lean(),
+        TempProjectScore.find({ date: day180 }).lean(),
       ]);
 
       // Create a map for quick lookup
@@ -153,6 +155,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const scoreMapDay7 = createScoreMap(scoresDay7);
       const scoreMapDay30 = createScoreMap(scoresDay30);
       const scoreMapDay90 = createScoreMap(scoresDay90);
+      const scoreMapDay180 = createScoreMap(scoresDay180);
 
       projects.forEach(project => {
         console.log(`Processing project ${project.name}`);
@@ -170,11 +173,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           const scoreDay7 = scoreMapDay7[projectId]?.[metric] || 0;
           const scoreDay30 = scoreMapDay30[projectId]?.[metric] || 0;
           const scoreDay90 = scoreMapDay90[projectId]?.[metric] || 0;
+          const scoreDay180 = scoreMapDay180[projectId]?.[metric] || 0;
 
           projectMovementData.movementByMetric[metric] = {
             7: getMovement(scoreToday, scoreDay7),
             30: getMovement(scoreToday, scoreDay30),
             90: getMovement(scoreToday, scoreDay90),
+            180: getMovement(scoreToday, scoreDay180),
           };
         }
 

--- a/packages/nextjs/services/mongodb/models/projectMovement.ts
+++ b/packages/nextjs/services/mongodb/models/projectMovement.ts
@@ -5,6 +5,7 @@ interface IMovementByMetric {
     "7": number;
     "30": number;
     "90": number;
+    "180": number;
   };
 }
 
@@ -20,6 +21,7 @@ const MovementByMetricSchema = new Schema({
   7: { type: Number, required: true },
   30: { type: Number, required: true },
   90: { type: Number, required: true },
+  180: { type: Number, required: true },
 });
 
 const ProjectMovementSchema: Schema = new Schema({


### PR DESCRIPTION
## Description

### This PR

- Adds  180 days to api/etl/index.ts
- Adds required types to IMovementByMetric
- Updates MovementByMetricSchema to include 180
- Adds a row to LeaderboardTable to display 180 days data
- Updates the table headers to have 180 days
- Updates skeleton to have one more column

I have tested that it works manually by re-running the etl logic after deleting the db. Feel free to make any changes + suggest improvements!

![image](https://github.com/user-attachments/assets/46649ee8-f0f5-4fb7-bcc9-c969bdb98517)

![image](https://github.com/user-attachments/assets/f01387e9-efa2-4db1-a1ba-6bf2cba5c6f4)

![image](https://github.com/user-attachments/assets/b1c1e9a0-6950-4340-b565-6bffaa419759)


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Fixes #65 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
