### PR TITLE
Match r4 impact metric calculation

### DIFF
--- a/packages/nextjs/pages/api/etl/index.ts
+++ b/packages/nextjs/pages/api/etl/index.ts
@@ -116,11 +116,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             globalScoreData.impact_index += impact_index;
           }
 
-          // Adjust to get the average impact_index for the day
-          if (globalScoreData.impact_index && osoData.length) {
-            globalScoreData.impact_index /= osoData.length;
-          }
-
           // Batch insert project scores
           if (projectScoreOps.length > 0) {
             await TempProjectScore.bulkWrite(projectScoreOps);

--- a/packages/nextjs/utils/onchainImpactDashboard/common.ts
+++ b/packages/nextjs/utils/onchainImpactDashboard/common.ts
@@ -47,7 +47,6 @@ export const stringToColor = (str: string): string => {
   if (!isColorWithinRange(color)) {
     return stringToColor(str + "a");
   }
-  console.log(`#${color}`);
   return `#${color}`;
 };
 


### PR DESCRIPTION
Closes: https://github.com/BuidlGuidl/onchain-impact-dashboard/issues/116

Additional context from TG:
@websurferdoteth Re:
```javascript
const shareForMetric = rawScoreForMetric / totalScoresForMetric;
impact_index += shareForMetric * multiplier;
```
I am finally getting into this and I am thinking it is more appropriate for it to be this:
```javascript
impact_index += rawScoreForMetric * multiplier;
```
Otherwise we are returning the projects share of the impact for that day instead of just the raw impact (adjusted by the weights). When viewing an individual project, I don't think it matters as compared to other projects as much as comparing to its own past performance. Am I missing something? I am putting a PR together if you want to see my line of thinking in detail.